### PR TITLE
Fix check for dns nameserver grain

### DIFF
--- a/haproxy/files/haproxy.cfg
+++ b/haproxy/files/haproxy.cfg
@@ -33,13 +33,12 @@ global
   ssl-default-server-ciphers ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS
   ssl-default-server-options no-sslv3 no-tls-tickets
 
-
   {% if 'nameservers' in grains['dns'] -%}
-  {% set nameservers = grains['dns']['nameservers'] -%}
-  {% elif 'name_servers' in grains['dns'] -%}
-  {% set nameservers = grains['dns']['name_servers'] -%}
-  {%  endif -%}
-  {% if nameservers %}
+  {%- set nameservers = grains['dns']['nameservers'] -%}
+  {% elif 'name_servers' in grains['dns'] %}
+  {%- set nameservers = grains['dns']['name_servers'] -%}
+  {%- endif %}
+  {% if nameservers -%}
   # Nameserver Options
   resolvers mydns
     {% for server in nameservers -%}
@@ -56,7 +55,6 @@ global
     hold obsolete 30s
   {%- endif %}
   {%- endif %}
-
 defaults
   log  global
   mode http

--- a/haproxy/files/haproxy.cfg
+++ b/haproxy/files/haproxy.cfg
@@ -33,6 +33,22 @@ global
   ssl-default-server-ciphers ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS
   ssl-default-server-options no-sslv3 no-tls-tickets
 
+  {% if grains['dns']['name_servers'] %}
+  # Nameserver Options
+  resolvers mydns
+    {% for server in grains['dns']['name_servers'] -%}
+    nameserver dns{{ loop.index }} {{ server }}:53
+    {% endfor %}
+    resolve_retries       3
+    timeout resolve       1s
+    timeout retry         1s
+    hold other           30s
+    hold refused         30s
+    hold nx              30s
+    hold timeout         30s
+    hold valid           10s
+    hold obsolete 30s
+  {%- endif %}
   {% if grains['dns']['nameservers'] %}
   # Nameserver Options
   resolvers mydns

--- a/haproxy/files/haproxy.cfg
+++ b/haproxy/files/haproxy.cfg
@@ -33,12 +33,8 @@ global
   ssl-default-server-ciphers ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS
   ssl-default-server-options no-sslv3 no-tls-tickets
 
-  {% if 'nameservers' in grains['dns'] -%}
-  {%- set nameservers = grains['dns']['nameservers'] -%}
-  {% elif 'name_servers' in grains['dns'] %}
-  {%- set nameservers = grains['dns']['name_servers'] -%}
-  {%- endif %}
-  {% if nameservers -%}
+  {% set nameservers = salt['grains.get']('dns:nameservers', salt['grains.get']('dns:name_servers', ["NAME_SERVER_GRAIN_NOT_FOUND"])) %}
+  {% if nameservers[0] != 'NAME_SERVER_GRAIN_NOT_FOUND' -%}
   # Nameserver Options
   resolvers mydns
     {% for server in nameservers -%}

--- a/haproxy/files/haproxy.cfg
+++ b/haproxy/files/haproxy.cfg
@@ -33,10 +33,16 @@ global
   ssl-default-server-ciphers ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS
   ssl-default-server-options no-sslv3 no-tls-tickets
 
-  {% if grains['dns']['name_servers'] %}
+
+  {% if 'nameservers' in grains['dns'] -%}
+  {% set nameservers = grains['dns']['nameservers'] -%}
+  {% elif 'name_servers' in grains['dns'] -%}
+  {% set nameservers = grains['dns']['name_servers'] -%}
+  {%  endif -%}
+  {% if nameservers -%}
   # Nameserver Options
   resolvers mydns
-    {% for server in grains['dns']['name_servers'] -%}
+    {% for server in nameservers -%}
     nameserver dns{{ loop.index }} {{ server }}:53
     {% endfor %}
     resolve_retries       3
@@ -49,23 +55,8 @@ global
     hold valid           10s
     hold obsolete 30s
   {%- endif %}
-  {% if grains['dns']['nameservers'] %}
-  # Nameserver Options
-  resolvers mydns
-    {% for server in grains['dns']['nameservers'] -%}
-    nameserver dns{{ loop.index }} {{ server }}:53
-    {% endfor %}
-    resolve_retries       3
-    timeout resolve       1s
-    timeout retry         1s
-    hold other           30s
-    hold refused         30s
-    hold nx              30s
-    hold timeout         30s
-    hold valid           10s
-    hold obsolete 30s
   {%- endif %}
-  {%- endif %}
+
 defaults
   log  global
   mode http

--- a/haproxy/files/haproxy.cfg
+++ b/haproxy/files/haproxy.cfg
@@ -39,7 +39,7 @@ global
   {% elif 'name_servers' in grains['dns'] -%}
   {% set nameservers = grains['dns']['name_servers'] -%}
   {%  endif -%}
-  {% if nameservers -%}
+  {% if nameservers %}
   # Nameserver Options
   resolvers mydns
     {% for server in nameservers -%}


### PR DESCRIPTION
Ok, so this check for `grains['dns']['nameserver']` exploded in my face with `Jinja variable 'dict object' has no attribute 'nameservers' saltstack` while trying to use this formula in the new PT salt environment.

This was due to in the old environment there is a grain `grains['dns']['nameserver']` and in the new environment the grain is called `grains['dns']['name_server']`

You can't check if a key in a dict is set that does not exist. So lets check if that key exists instead. Then set a variable to that key's contents and use that instead.

So this fixes that issue.
This was tested to make sure that we produce the same output as to not cause a restart of haproxy service where we already use this.

TL;DR:
This check for `grains['dns']['nameserver']` did not work as intended, this fixes that.